### PR TITLE
fix(config): add missing user command

### DIFF
--- a/lua/gentags.lua
+++ b/lua/gentags.lua
@@ -72,6 +72,18 @@ M.setup = function(opts)
       require("gentags.dispatcher").terminate()
     end,
   })
+
+  -- register user command
+  if cfg.command then
+    vim.api.nvim_create_user_command(cfg.command.name, function(args)
+        local dispatcher = require("gentags.dispatcher")
+        if dispatcher.enabled() then
+          dispatcher.update()
+        end
+      end, {
+        desc = cfg.command.desc,
+    })
+  end
 end
 
 return M


### PR DESCRIPTION
There is only a user command option in config, this patch register the configed user command to nvim. Tested localy on windows.